### PR TITLE
[Fix] deliveries_index/[Update] orders#confirm

### DIFF
--- a/app/views/user/deliveries/index.html.erb
+++ b/app/views/user/deliveries/index.html.erb
@@ -3,36 +3,36 @@
     <h2><span style="background-color: #F5F5F5;">配送先登録/一覧</span></h2>
     <!-- フラッシュメッセージ -->
     <p id="notice"><%= notice %></p>
-    <table style="border:none; border-collapse: separate;
+    <%= form_for @delivery, url: user_user_deliveries_path do |f| %>
+      <table style="border:none; border-collapse: separate;
 border-spacing: 20px 10px;" width="700">
-      <%= form_for @delivery, url: user_user_deliveries_path do |f| %>
-      <!-- エラーメッセージ -->
-      <% if @delivery.errors.any? %>
-      <div id="error_explanation">
-        <h3><%= pluralize(@delivery.errors.count, "error") %> prohibited this product from being saved:</h3>
+        <!-- エラーメッセージ -->
+        <% if @delivery.errors.any? %>
+        <div id="error_explanation">
+          <h3><%= pluralize(@delivery.errors.count, "error") %> prohibited this product from being saved:</h3>
 
-        <ul>
-        <% @delivery.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-        </ul>
-      </div>
-    <% end %>
-      <tr>
-        <th><%= f.label :'郵便番号(ハイフンなし)' %></th>
-        <td><%= f.text_field :post_number %></td>
-      </tr>
-      <tr>
-        <th><%= f.label :'住所' %></th>
-        <td><%= f.text_field :post_address, size: "50x10" %></td>
-      </tr>
-      <tr>
-        <th><%= f.label :'宛名' %></th>
-        <td><%= f.text_field :post_name %></td>
-        <td><%= f.submit "登録する", class: 'btn btn-success btn-block' %></td>
-      </tr>
+          <ul>
+          <% @delivery.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+          </ul>
+        </div>
       <% end %>
-    </table>
+        <tr>
+          <th><%= f.label :'郵便番号(ハイフンなし)' %></th>
+          <td><%= f.text_field :post_number %></td>
+        </tr>
+        <tr>
+          <th><%= f.label :'住所' %></th>
+          <td><%= f.text_field :post_address, size: "50x10" %></td>
+        </tr>
+        <tr>
+          <th><%= f.label :'宛名' %></th>
+          <td><%= f.text_field :post_name %></td>
+          <td><%= f.submit "登録する", class: 'btn btn-success btn-block' %></td>
+        </tr>
+      </table>
+    <% end %>
 ​
     <table class="table table-hover table-bordered">
       <thead>

--- a/app/views/user/orders/confirm.html.erb
+++ b/app/views/user/orders/confirm.html.erb
@@ -4,7 +4,7 @@
 <div class="row">
   <!-- 商品一覧テーブル -->
   <%= form_for @order, url: user_user_orders_path(user_id: current_user.id) do |f| %>
-    <div class="col-xs-8">
+    <div class="col-xs-9">
       <table class="table table-bordered">
         <thead>
           <tr class="active">
@@ -15,23 +15,38 @@
           </tr>
         </thead>
         <tbody>
-            <!-- cart_item出来たら -->
+          <% @cart_items.each do |cart_item| %>
+            <tr>
+              <!-- '&nbsp;'は空白を開けるための文字列 -->
+              <td><%= attachment_image_tag(cart_item.product, :image, :fill, 30, 30, fallback: "no_image.jpg") %>&nbsp;<%= cart_item.product.name %></td>
+              <td><%= (cart_item.product.price * cart_item.product.tax_rate).round %></td>
+              <td><%= cart_item.count %></td>
+              <td><%= (cart_item.product.price * cart_item.product.tax_rate).round * cart_item.count %></td>
+            </tr>
+          <% end %>
         </tbody>
       </table>
     </div>
-    <div class="col-xs-4">
+    <div class="col-xs-3">
       <table class="table table-bordered">
         <tr>
           <td class="active">送料</td>
-          <td></td>
+          <td>
+            <%= f.hidden_field :postage %>
+            <%= @order.postage %>
+          </td>
         </tr>
         <tr>
           <td class="active">商品合計</td>
-          <td></td>
+          <td><%= @total %></td>
         </tr>
         <tr>
           <td class="active">請求金額</td>
-          <td></td>
+          <td>
+            <!-- valueで渡す値を指定 -->
+            <%= f.hidden_field :total_price, value: @total + @order.postage %>
+            <%= @total + @order.postage %>
+          </td>
         </tr>
       </table>
     </div>
@@ -41,7 +56,8 @@
 border-spacing: 20px 10px;" width="600">
           <tr>
             <th>支払い方法</th>
-            <td><%= f.hidden_field :payment_method %>
+            <td>
+              <%= f.hidden_field :payment_method %>
               <%= @order.payment_method %></td>
           </tr>
           <tr>

--- a/db/migrate/20200402080828_create_orders.rb
+++ b/db/migrate/20200402080828_create_orders.rb
@@ -2,9 +2,9 @@ class CreateOrders < ActiveRecord::Migration[5.2]
   def change
     create_table :orders do |t|
       t.integer :user_id
-      t.integer :postage, default: 1.08
+      t.integer :postage, default: 800
       t.integer :total_price
-      t.integer :request_status
+      t.integer :request_status, default: 0
       t.string :post_number
       t.string :post_address
       t.string :post_name


### PR DESCRIPTION
・配送先一覧/追加画面
「登録する」ボタンがリロードしないと機能しなかったのでformタグの位置を調整
・注文確認画面のアップデート
　カート情報の取得
　購入確定時にカートを空にする。